### PR TITLE
fixes mingw cross compiling for ctime path generation

### DIFF
--- a/zstd/common.nim
+++ b/zstd/common.nim
@@ -1,23 +1,51 @@
 import std/os
 import std/strutils
+from os {.all.} import parentDirPos # for parentDirHost
 
-const cur_src_path = currentSourcePath.rsplit(DirSep, 1)[0]
-const zstd_path {.strdefine.}: string = joinPath(cur_src_path, "deps/zstd")
-const dep_lib_dir* = joinPath(zstd_path, "lib")
+
+proc joinPathHost*(head, tail: string): string {.noSideEffect.} =
+  when not defined(mingw):
+    joinPath(head, tail)
+  else:
+    head & '/' & tail
+
+proc joinPathHost*(parts: varargs[string]): string {.noSideEffect.} =
+  when not defined(mingw):
+    joinPath(parts)
+  else:
+    if parts.len == 1: return parts[0]
+    else:
+      result = parts[0]
+      for part in parts:
+        result.add '/' & part
+
+proc parentDirHost*(path: string): string =
+  var sepPos = parentDirPos(path)
+  if sepPos >= 0:
+    result = substr(path, 0, sepPos)
+    normalizePathEnd(result)
+  elif result == ".." or result == "." or result.len == 0 or result[^1] in {DirSep, AltSep}:
+    result = ""
+  else:
+    result = "."
+
+const cur_src_path = currentSourcePath.parentDirHost
+const zstd_path {.strdefine.}: string = joinPathHost(cur_src_path, "deps/zstd")
+const dep_lib_dir* = joinPathHost(zstd_path, "lib")
 
 when defined(useExternalZstd):
   {.passL: "-lzstd".}
 else:
   {.passC: "-I" & dep_lib_dir.}
-  {.passC: "-I" & joinPath(dep_lib_dir, "common").}
-  {.compile: joinPath(dep_lib_dir, "common/debug.c").}
-  {.compile: joinPath(dep_lib_dir, "common/entropy_common.c").}
-  {.compile: joinPath(dep_lib_dir, "common/error_private.c").}
-  {.compile: joinPath(dep_lib_dir, "common/fse_decompress.c").}
-  {.compile: joinPath(dep_lib_dir, "common/pool.c").}
-  {.compile: joinPath(dep_lib_dir, "common/threading.c").}
-  {.compile: joinPath(dep_lib_dir, "common/xxhash.c").}
-  {.compile: joinPath(dep_lib_dir, "common/zstd_common.c").}
+  {.passC: "-I" & joinPathHost(dep_lib_dir, "common").}
+  {.compile: joinPathHost(dep_lib_dir, "common/debug.c").}
+  {.compile: joinPathHost(dep_lib_dir, "common/entropy_common.c").}
+  {.compile: joinPathHost(dep_lib_dir, "common/error_private.c").}
+  {.compile: joinPathHost(dep_lib_dir, "common/fse_decompress.c").}
+  {.compile: joinPathHost(dep_lib_dir, "common/pool.c").}
+  {.compile: joinPathHost(dep_lib_dir, "common/threading.c").}
+  {.compile: joinPathHost(dep_lib_dir, "common/xxhash.c").}
+  {.compile: joinPathHost(dep_lib_dir, "common/zstd_common.c").}
 
 let dep_header_name* {.compileTime.} = "zstd.h"
 {.pragma: c_dep_type, header: dep_header_name, bycopy.}

--- a/zstd/compress.nim
+++ b/zstd/compress.nim
@@ -3,20 +3,20 @@ import ./common
 
 when not defined(useExternalZstd):
   import std/os
-  {.passC: "-I" & joinPath(dep_lib_dir, "compress").}
-  {.compile: joinPath(dep_lib_dir, "compress/fse_compress.c").}
-  {.compile: joinPath(dep_lib_dir, "compress/hist.c").}
-  {.compile: joinPath(dep_lib_dir, "compress/huf_compress.c").}
-  {.compile: joinPath(dep_lib_dir, "compress/zstd_compress.c").}
-  {.compile: joinPath(dep_lib_dir, "compress/zstd_compress_literals.c").}
-  {.compile: joinPath(dep_lib_dir, "compress/zstd_compress_sequences.c").}
-  {.compile: joinPath(dep_lib_dir, "compress/zstd_compress_superblock.c").}
-  {.compile: joinPath(dep_lib_dir, "compress/zstd_double_fast.c").}
-  {.compile: joinPath(dep_lib_dir, "compress/zstd_fast.c").}
-  {.compile: joinPath(dep_lib_dir, "compress/zstd_lazy.c").}
-  {.compile: joinPath(dep_lib_dir, "compress/zstd_ldm.c").}
-  {.compile: joinPath(dep_lib_dir, "compress/zstdmt_compress.c").}
-  {.compile: joinPath(dep_lib_dir, "compress/zstd_opt.c").}
+  {.passC: "-I" & joinPathHost(dep_lib_dir, "compress").}
+  {.compile: joinPathHost(dep_lib_dir, "compress/fse_compress.c").}
+  {.compile: joinPathHost(dep_lib_dir, "compress/hist.c").}
+  {.compile: joinPathHost(dep_lib_dir, "compress/huf_compress.c").}
+  {.compile: joinPathHost(dep_lib_dir, "compress/zstd_compress.c").}
+  {.compile: joinPathHost(dep_lib_dir, "compress/zstd_compress_literals.c").}
+  {.compile: joinPathHost(dep_lib_dir, "compress/zstd_compress_sequences.c").}
+  {.compile: joinPathHost(dep_lib_dir, "compress/zstd_compress_superblock.c").}
+  {.compile: joinPathHost(dep_lib_dir, "compress/zstd_double_fast.c").}
+  {.compile: joinPathHost(dep_lib_dir, "compress/zstd_fast.c").}
+  {.compile: joinPathHost(dep_lib_dir, "compress/zstd_lazy.c").}
+  {.compile: joinPathHost(dep_lib_dir, "compress/zstd_ldm.c").}
+  {.compile: joinPathHost(dep_lib_dir, "compress/zstdmt_compress.c").}
+  {.compile: joinPathHost(dep_lib_dir, "compress/zstd_opt.c").}
 
 {.pragma: c_dep_type, header: dep_header_name, bycopy.}
 {.pragma: c_dep_proc, importc, header: dep_header_name, cdecl.}

--- a/zstd/decompress.nim
+++ b/zstd/decompress.nim
@@ -3,11 +3,11 @@ import ./common
 
 when not defined(useExternalZstd):
   import std/os
-  {.passC: "-I" & joinPath(dep_lib_dir, "decompress").}
-  {.compile: joinPath(dep_lib_dir, "decompress/huf_decompress.c").}
-  {.compile: joinPath(dep_lib_dir, "decompress/zstd_ddict.c").}
-  {.compile: joinPath(dep_lib_dir, "decompress/zstd_decompress_block.c").}
-  {.compile: joinPath(dep_lib_dir, "decompress/zstd_decompress.c").}
+  {.passC: "-I" & joinPathHost(dep_lib_dir, "decompress").}
+  {.compile: joinPathHost(dep_lib_dir, "decompress/huf_decompress.c").}
+  {.compile: joinPathHost(dep_lib_dir, "decompress/zstd_ddict.c").}
+  {.compile: joinPathHost(dep_lib_dir, "decompress/zstd_decompress_block.c").}
+  {.compile: joinPathHost(dep_lib_dir, "decompress/zstd_decompress.c").}
 
 {.pragma: c_dep_type, header: dep_header_name, bycopy.}
 {.pragma: c_dep_proc, importc, header: dep_header_name, cdecl.}


### PR DESCRIPTION
Sorry this wasn't one of your TODO items ;)
This actually uncovered some missing functionality in nim's std lib. We need some ways to be specific about the system we're on vs producing strings for.