### PR TITLE
Fix compile error in Nim devel

### DIFF
--- a/zstd/common.nim
+++ b/zstd/common.nim
@@ -1,5 +1,5 @@
 import std/os
-from os {.all.} import parentDirPos # for parentDirHost
+import zstd/private/ospath
 
 proc joinPathHost*(head, tail: string): string {.noSideEffect.} =
   when not defined(mingw):

--- a/zstd/private/ospath.nim
+++ b/zstd/private/ospath.nim
@@ -1,0 +1,34 @@
+## =====================================================
+## Nim -- a Compiler for Nim. https://nim-lang.org/
+##
+## Copyright (C) 2006-2022 Andreas Rumpf. All rights reserved.
+##
+## Permission is hereby granted, free of charge, to any person obtaining a copy
+## of this software and associated documentation files (the "Software"), to deal
+## in the Software without restriction, including without limitation the rights
+## to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+## copies of the Software, and to permit persons to whom the Software is
+## furnished to do so, subject to the following conditions:
+##
+## The above copyright notice and this permission notice shall be included in
+## all copies or substantial portions of the Software.
+##
+## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+## IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+## FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+## AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+## LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+## OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+## THE SOFTWARE.
+##
+## [ MIT license: http://www.opensource.org/licenses/mit-license.php ]
+
+import std/os
+
+proc parentDirPos*(path: string): int =
+  ## Copied from Nim/lib/std/private/ospaths2.nim.
+  var q = 1
+  if len(path) >= 1 and path[len(path)-1] in {DirSep, AltSep}: q = 2
+  for i in countdown(len(path)-q, 0):
+    if path[i] in {DirSep, AltSep}: return i
+  result = -1


### PR DESCRIPTION
Cannot compile nim_zstd in Nim devel.

```
$ nim -v

Nim Compiler Version 1.9.1 [Linux: amd64]
Compiled at 2022-12-20
Copyright (c) 2006-2022 by Andreas Rumpf

git hash: e278a781fc5bfc115326ed6c1873268d51b25303
active boot switches: -d:release
```
```
Hint: used config file '/home/fox/.choosenim/toolchains/nim-#devel/config/nim.cfg' [Conf]
Hint: used config file '/home/fox/.choosenim/toolchains/nim-#devel/config/config.nims' [Conf]
.................................................................................................................
/home/fox/.nimble/pkgs2/zstd-0.6.0-239209f862ae556be1def21dabe5c7d2a619ff93/zstd/common.nim(2, 24) Error: undeclared identifier: 'parentDirPos'
```
`parentDirPos` removed from `std/os`.

## Solution
Copied `parentDirPos` from `Nim/lib/std/private/ospaths2.nim`